### PR TITLE
RealizeAccpet subroutine added for realizing fields which are accepting the grid from ocean model component 

### DIFF
--- a/nuopc_dart.f90
+++ b/nuopc_dart.f90
@@ -148,7 +148,7 @@ module dart_comp_nuopc
   
   
   
-    subroutine InitializeRealize(dgcomp, rc)
+    subroutine RealizeProvided(dgcomp, rc)
       type(ESMF_GridComp)    :: dgcomp                    !< ESMF_GridComp object
       type(ESMF_State)       :: importState, exportState !< ESMF_State object for
                                                        !! import/export fields
@@ -247,7 +247,7 @@ module dart_comp_nuopc
         return ! bail out
 
 
-    end subroutine InitializeRealize
+    end subroutine RealizeProvided
     
 
     ! In this routine the DART component can access the transferred grid/mesh/locstream on the field that have "accept" value. 

--- a/nuopc_dart.f90
+++ b/nuopc_dart.f90
@@ -1,3 +1,5 @@
+#define TEST_MULTI_TILE_GRID
+
 module dart_comp_nuopc
   ! this is a dummy DART Component to be used to temporarily build a dummy libesp.a
   
@@ -841,48 +843,48 @@ module dart_comp_nuopc
     ! stopTime of the internal Clock has been reached.
 
     
-    call ESMF_ClockPrint(clock, options="currTime", &
-    preString="------>Advancing DART from: ", unit=msgString, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    
-    call ESMF_ClockPrint(clock, options="stopTime", &
-      preString="--------------------------------> to: ", unit=msgString, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+      call ESMF_ClockPrint(clock, options="currTime", &
+      preString="------>Advancing DART from: ", unit=msgString, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      
+      call ESMF_ClockPrint(clock, options="stopTime", &
+        preString="--------------------------------> to: ", unit=msgString, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      call ESMF_LogWrite(msgString, ESMF_LOGMSG_INFO, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
     
     ! write out the fields in the importState and exportState
-#ifdef TEST_MULTI_TILE_GRID
-    call NUOPC_Write(importState, fileNamePrefix="field_DART_import_", &
-      timeslice=slice, overwrite=.true., relaxedflag=.true., rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
+#ifndef TEST_MULTI_TILE_GRID
+      call NUOPC_Write(importState, fileNamePrefix="field_DART_import_", &
+        timeslice=slice, overwrite=.true., relaxedflag=.true., rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
 #endif
 
-    call NUOPC_Write(exportState, fileNamePrefix="field_DART_export_", &
-      timeslice=slice, overwrite=.true., relaxedflag=.true., rc=rc)
-    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
-      line=__LINE__, &
-      file=__FILE__)) &
-      return  ! bail out
-    
-    slice = slice+1
+      call NUOPC_Write(exportState, fileNamePrefix="field_DART_export_", &
+        timeslice=slice, overwrite=.true., relaxedflag=.true., rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__, &
+        file=__FILE__)) &
+        return  ! bail out
+      
+      slice = slice+1
     end subroutine ModelAdvance
   
   


### PR DESCRIPTION
There are two subroutine of realization of the fields in the code. One is RealizeProvided and second one is RealizeProvided and other is RealizeAccept. RealizeProvided would realize fields which is willing to provide grid, i.e. DART is willing to provide grid for those fields and RealizeAccept is where realization of field is happening who are accepting grid from ocean model component.