### PR TITLE
Added DART as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "DART"]
+	path = DART
+	url = https://github.com/DART-NUOPC/DART.git


### PR DESCRIPTION
git is tracking DART which is a separate repository where the actual code for nuopc dart interface is stored and the newly written model_mod.f90 under DART/models/NUOPC/model_mod.F90 is stored! 